### PR TITLE
Fix Flutter WASM: remove dart:io / dart:html usage so app runs on web (WASM)

### DIFF
--- a/lib/src/fp_web.dart
+++ b/lib/src/fp_web.dart
@@ -1,4 +1,4 @@
-import 'dart:html';
+import 'package:web/web.dart';
 
 /// This is a fingerprint of the host environment. It is used to help
 /// prevent collisions when generating ids in a distributed system.

--- a/lib/src/utility.dart
+++ b/lib/src/utility.dart
@@ -5,7 +5,9 @@ import 'dart:typed_data';
 import 'package:cuid2/src/cuid2_base.dart';
 import 'package:pointycastle/digests/sha3.dart';
 
-import './fp_native.dart' if (dart.library.html) './fp_web.dart' as fp_native;
+// Use native (dart:io) fingerprint on VM/native; use web stub on web/WASM.
+// dart.library.html can be false for WASM, so we key off dart.library.io instead.
+import './fp_web.dart' if (dart.library.io) './fp_native.dart' as fp_native;
 
 /// Adapted from https://github.com/juanelas/bigint-conversion
 /// MIT License Copyright (c) 2018 Juan Hernández Serrano

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ executables:
 
 dependencies:
   pointycastle: ^3.9.1
+  web: ^1.1.1
 
 dev_dependencies:
   lints: ^3.0.0


### PR DESCRIPTION
Web/WASM → use fp_web.dart, native → fp_native.dart
Replaced dart:html with package:web